### PR TITLE
set max-widht to 100% for embeds

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -80,7 +80,7 @@ li {
   line-height: 1.4;
 }
 
-img {
+img, embed {
   max-width: 100%;
   display: block;
   margin: 0 auto;


### PR DESCRIPTION
this is so that an embed does not redner the page unnecessarily wide on mobile

# Before
![screenshot-2017-12-29 wir veroffentlichen reformvorschlag des justizministeriums zu mord-paragrafen fragdenstaat de blog 1](https://user-images.githubusercontent.com/1096357/34440202-c7091de2-ecb3-11e7-8c16-86836e2a1b63.png)

# After
![screenshot-2017-12-29 wir veroffentlichen reformvorschlag des justizministeriums zu mord-paragrafen fragdenstaat de blog](https://user-images.githubusercontent.com/1096357/34440201-c6ef8800-ecb3-11e7-83ee-004a90458dbd.png)